### PR TITLE
fix: choose playlist by resolution height

### DIFF
--- a/src/choose-playlists.js
+++ b/src/choose-playlists.js
@@ -39,8 +39,8 @@ export const chooseVideoPlaylists = (manifestsPlaylists, targetVerticalResolutio
           return playlist;
         }
 
-        if (Math.abs(playlist.attributes.RESOLUTION - targetVerticalResolution) <
-            Math.abs(acc.attributes.RESOLUTION - targetVerticalResolution)) {
+        if (Math.abs(playlist.attributes.RESOLUTION.height - targetVerticalResolution) <
+            Math.abs(acc.attributes.RESOLUTION.height - targetVerticalResolution)) {
           return playlist;
         }
         return acc;

--- a/test/choose-playlists.test.js
+++ b/test/choose-playlists.test.js
@@ -8,9 +8,9 @@ import {
 QUnit.module('chooseVideoPlaylists');
 
 QUnit.test('chooses video playlists by target vertical resolution', function(assert) {
-  const playlist1 = { attributes: { RESOLUTION: 1 } };
-  const playlist2 = { attributes: { RESOLUTION: 719 } };
-  const playlist3 = { attributes: { RESOLUTION: 722 } };
+  const playlist1 = { attributes: { RESOLUTION: {width: 2, height: 1} } };
+  const playlist2 = { attributes: { RESOLUTION: {width: 1000, height: 719}}};
+  const playlist3 = { attributes: { RESOLUTION: {width: 1000, height: 722 }} };
 
   assert.deepEqual(
     chooseVideoPlaylists(


### PR DESCRIPTION
Bug fix: `targetVerticalResolution` option has no effect.

When comparing resolutions `choose-playlist` always returns the first resolution because `attributes.RESOLUTION` is an object rather than a number. 

